### PR TITLE
Remove PHP 8.1 deprecations

### DIFF
--- a/src/ShortidType.php
+++ b/src/ShortidType.php
@@ -44,7 +44,7 @@ final class ShortidType extends Type
         if (empty($value)) {
             return null;
         }
-        if (ShortId::isValid($value)) {
+        if (ShortId::isValid((string) $value)) {
             return new Shortid($value);
         }
 
@@ -59,7 +59,7 @@ final class ShortidType extends Type
         if (empty($value)) {
             return null;
         }
-        if ($value instanceof ShortId || ShortId::isValid($value)) {
+        if ($value instanceof ShortId || ShortId::isValid((string) $value)) {
             return (string) $value;
         }
 

--- a/src/ShortidType.php
+++ b/src/ShortidType.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PUGX\Shortid\Doctrine;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;

--- a/src/ShortidType.php
+++ b/src/ShortidType.php
@@ -19,7 +19,7 @@ final class ShortidType extends Type
     public const NAME = 'shortid';
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
@@ -35,7 +35,7 @@ final class ShortidType extends Type
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function convertToPHPValue($value, AbstractPlatform $platform): ?Shortid
     {
@@ -50,7 +50,7 @@ final class ShortidType extends Type
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
@@ -58,14 +58,14 @@ final class ShortidType extends Type
             return null;
         }
         if ($value instanceof ShortId || ShortId::isValid($value)) {
-            return (string)$value;
+            return (string) $value;
         }
 
         throw ConversionException::conversionFailed($value, self::NAME);
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getName(): string
     {
@@ -73,7 +73,7 @@ final class ShortidType extends Type
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {

--- a/src/ShortidType.php
+++ b/src/ShortidType.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 namespace PUGX\Shortid\Doctrine;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -18,6 +18,9 @@ final class ShortidType extends Type
 {
     public const NAME = 'shortid';
 
+    /**
+     * @inheritdoc
+     */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         $length = $column['length'] ?? 7;
@@ -31,10 +34,13 @@ final class ShortidType extends Type
         return $platform->getVarcharTypeDeclarationSQL($field).' '.$platform->getColumnCollationDeclarationSQL('utf8_bin');
     }
 
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    /**
+     * @inheritdoc
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?Shortid
     {
         if (empty($value)) {
-            return;
+            return null;
         }
         if (ShortId::isValid($value)) {
             return new Shortid($value);
@@ -43,23 +49,32 @@ final class ShortidType extends Type
         throw ConversionException::conversionFailed($value, self::NAME);
     }
 
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    /**
+     * @inheritdoc
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
         if (empty($value)) {
-            return;
+            return null;
         }
         if ($value instanceof ShortId || ShortId::isValid($value)) {
-            return $value;
+            return (string)$value;
         }
 
         throw ConversionException::conversionFailed($value, self::NAME);
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getName(): string
     {
         return self::NAME;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return true;

--- a/src/ShortidType.php
+++ b/src/ShortidType.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace PUGX\Shortid\Doctrine;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;

--- a/src/ShortidType.php
+++ b/src/ShortidType.php
@@ -1,7 +1,4 @@
 <?php
-
-declare(strict_types=1);
-
 namespace PUGX\Shortid\Doctrine;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -20,9 +17,6 @@ final class ShortidType extends Type
 {
     public const NAME = 'shortid';
 
-    /**
-     * {@inheritdoc}
-     */
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
         $length = $column['length'] ?? 7;
@@ -36,47 +30,35 @@ final class ShortidType extends Type
         return $platform->getVarcharTypeDeclarationSQL($field).' '.$platform->getColumnCollationDeclarationSQL('utf8_bin');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function convertToPHPValue($value, AbstractPlatform $platform): ?Shortid
     {
         if (empty($value)) {
             return null;
         }
-        if (ShortId::isValid((string) $value)) {
+        if (ShortId::isValid($value)) {
             return new Shortid($value);
         }
 
         throw ConversionException::conversionFailed($value, self::NAME);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
         if (empty($value)) {
             return null;
         }
-        if ($value instanceof ShortId || ShortId::isValid((string) $value)) {
+        if ($value instanceof ShortId || ShortId::isValid($value)) {
             return (string) $value;
         }
 
         throw ConversionException::conversionFailed($value, self::NAME);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getName(): string
     {
         return self::NAME;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return true;

--- a/tests/ShortidTypeTest.php
+++ b/tests/ShortidTypeTest.php
@@ -60,7 +60,7 @@ final class ShortidTypeTest extends TestCase
     {
         $shortid = $this->getMockBuilder(Shortid::class)->disableOriginalConstructor()->getMock();
         $converted = $this->type->convertToDatabaseValue($shortid, $this->platform);
-        self::assertInstanceOf(Shortid::class, $converted);
+        self::assertIsString($converted);
     }
 
     public function testConvertToDatabaseValueException(): void


### PR DESCRIPTION
The missing return types of the `ShortidType::convertToDatabaseValue()` and the `ShortidType::convertToPHPValue()` methods raised deprecation warnings with PHP 8.1, so I introduced them with a strict scope. Returning nothing from these methods does not seem like a good practice, so I returned null, when $value is empty instead. And `ShortidType::convertToDatabaseValue()` should IMHO do an explicit string cast instead of relying on an automatic type conversion later on. All that changes also allowed enabling the strict type for that file.

I also added inheritdoc annotations to mark the methods as overriding.